### PR TITLE
Attempt to make routes case-insensitive

### DIFF
--- a/pages/[slug].js
+++ b/pages/[slug].js
@@ -498,7 +498,7 @@ export function getStaticProps({ params }) {
   manifest.map(section => {
     section.items.map(item => {
       if (item.path) {
-        if (item.path.replace('.mdx', '') == slug) {
+        if (item.path.replace('.mdx', '').toLowerCase() === slug.toLowerCase()) {
           currentItem = item
         }
       }


### PR DESCRIPTION
I saw after reading [this thread in Slack](https://hackclub.slack.com/archives/C0JDWKJVA/p1636727456238800) that `toolbox.hackclub.com/CodeDay` returned a 404 because it didn't match the slug `/codeday`. This is my attempt to make routes case-insensitive.