### PR TITLE
update HCB icon

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -146,7 +146,7 @@ export default [
         name: "HCB",
         description:
           "A full-stack toolkit for organizing anything.",
-        icon: "university",
+        icon: "bank-account",
         external: true,
         url: "https://hackclub.com/hcb",
         forUseBy: "everyone",


### PR DESCRIPTION
Changes HCB's icon from `university` (which doesn't exist) to [`bank-account`](https://icons.hackclub.com/api/icons/hackclub-blue/bank-account).