### PR TITLE
Update manifest.js

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -45,8 +45,8 @@ export default [
         forUseBy: "leaders",
       },
       {
-        name: "Posters - Europe",
-        description: "If you're in Europe, get large Hack Club posters to promote your Hack Club",
+        name: "Posters - International",
+        description: "If you're in outside the US or Canada, get large Hack Club posters to promote your Hack Club",
         icon: "docs-fill",
         external: true,
         url: "https://hack.club/eu-posters",


### PR DESCRIPTION
Changed 'Posters - Europe' to 'Posters - International' Changed 'in Europe' to 'outside the US or Canada'

This order form is for all leaders living outside the US and Canada but everything said Europe instead.