### PR TITLE
remove Tonic's "Ends Mid May"

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -97,7 +97,7 @@ export default [
       // Limited-time YSWSs start here
       {
         name: "Tonic",
-        description: "Make a Jekyll theme, show it to the world, and get a Hack Club hat (Ends Mid May)",
+        description: "Make a Jekyll theme, show it to the world, and get a Hack Club hat",
         img: "/cards/tonic.png",
         background: "#faebd7",
         titleColor: "#706044",


### PR DESCRIPTION
the card for Tonic currently reads "Ends Mid May". by my count, it is now mid-May, so this is no longer an accurate estimate. this PR removes that text from the card.