### PR TITLE
Remove Jet Fund [Temporarily]

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -318,15 +318,6 @@ export default [
         url: 'https://gas.hackclub.com/',
         forUseBy: 'everyone'
       },
-      // {
-      //   name: 'Jet Fund',
-      //   description:
-      //     'Fly to any high school hackathon and get the flights reimbursed',
-      //   icon: 'send',
-      //   external: true,
-      //   url: 'https://jet.hackclub.com/',
-      //   forUseBy: 'everyone'
-      // },
       {
         name: 'Hackathons Page',
         description:


### PR DESCRIPTION
Jet fund is ~~paused long-term~~ dead and ~~might not~~ seems unlikely to return. Right now its sorta misleading to keep making it seem like it presently exists as a resource clubs/HCers can use and not just an experiment which is being considered to potentially run long-term. As a result, I have commented it out until the program's future becomes more clear / it is operational again.

(gas fund is obviously still alive and ~~kicking~~ driving so I have left it untouched!!)
