### PR TITLE
docs: clarify CodeCrafters perk is for clubs only

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -482,7 +482,7 @@ export default [
       },
       {
         name: 'Code Crafters',
-        description: 'Free 2-year membership to CodeCrafters',
+        description: 'Free 2-year membership to CodeCrafters (Clubs Only)',
         icon: 'code',
         external: true,
         url: 'https://codecrafters.io/event/hackclub',


### PR DESCRIPTION
since people are getting confused in #hq [that codecrafters are for everyone](https://hackclub.enterprise.slack.com/archives/C0C78SG9L/p1778502882492519?thread_ts=1778502882.492519&cid=C0C78SG9L) even though it's for clubs, i think it's better to clarify that it's for clubs only :3