### PR TITLE
Update stickers URL to club-stickers

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -265,7 +265,7 @@ export default [
         description: 'Get a box of stickers for your next meeting or event',
         icon: 'sticker',
         external: true,
-        url: 'https://forms.hackclub.com/stickers',
+        url: 'http://forms.hackclub.com/club-stickers',
         forUseBy: 'leaders'
       },
       {


### PR DESCRIPTION
I changed the URL so that instead of the old broken Form, it sends you to the brand new Club Stickers form that @jps recently made.