### PR TITLE
Use hackclub.com instead of hackclub.github.io in map

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -105,7 +105,7 @@ export default function Map() {
           left: 0,
           border: 'none'
         }}
-        src="https://hackclub.github.io/map/"
+        src="https://hackclub.com/map/"
         height="500px"
         width="100%"
       />
@@ -140,7 +140,7 @@ export default function Map() {
             }}
             onClick={event => event.stopPropagation()}
           >
-            <Embed src="https://hackclub.github.io/map/" />
+            <Embed src="https://hackclub.com/map/" />
           </Box>
         </Box>
       )}


### PR DESCRIPTION
https://hackclub.com/map/ is the URL that's more canonical (eg referenced in https://hackclub.com/map/)