### PR TITLE
Add Breadboard to the YSWSs category

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -117,6 +117,18 @@ export default [
         url: "https://trailit.hackclub.com",
         fancy: true,
       },
+      {
+        name: 'Breadboard',
+        description:
+          'Design a real breadboard project, get a free component kit shipped to you to build it!',
+        img: 'https://breadboard.hackclub.com/assets/Breadboard_Logo_White.svg',
+        background: '#17171d',
+        titleColor: '#ffffff',
+        descriptionColor: '#ffffff',
+        external: true,
+        url: 'https://breadboard.hackclub.com',
+        fancy: true
+      },
     ]
   },
   {


### PR DESCRIPTION
Adds [Breadboard](https://breadboard.hackclub.com) to the YSWSs category.

Breadboard is a YSWS run by high schoolers where you design a real breadboard electronics project on an online editor, then get a free component kit shipped to you to build it. It's open to teens 13-18 worldwide of all skill levels, with no prior electronics experience required.

The card links to https://breadboard.hackclub.com and uses the program's logo on a dark background so it fits in with the other YSWS cards.
