### PR TITLE
Update Breadboard card description

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -120,7 +120,7 @@ export default [
       {
         name: 'Breadboard',
         description:
-          'Design a real breadboard project, get a free component kit shipped to you to build it!',
+          'Design a breadboard project, get a free component kit shipped to you and other cool prizes!',
         img: 'https://breadboard.hackclub.com/assets/Breadboard_Logo_White.svg',
         background: '#17171d',
         titleColor: '#ffffff',


### PR DESCRIPTION
Follow-up to #297. This updates the Breadboard card description to mention that builders can earn other prizes too, not just the component kit.

Old: Design a real breadboard project, get a free component kit shipped to you to build it!
New: Design a breadboard project, get a free component kit shipped to you and other cool prizes!