### PR TITLE
Organise Toolbox resources into clearer categories & add new Resources / Cards

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -295,37 +295,12 @@ export default [
         descriptionColor: "#ffffff",
       },
       {
-        name: 'Posters',
-        description: 'Get large Hack Club posters to promote your Hack Club (US)',
-        icon: 'docs-fill',
-        external: true,
-        url: 'https://forms.hackclub.com/club-stickers',
-        forUseBy: 'leaders'
-      },
-      {
-        name: 'International Posters',
-        description:
-          "If you're outside of the US, get large Hack Club posters to promote your Hack Club",
-        icon: 'docs-fill',
-        external: true,
-        url: 'https://are-we-there-yet.hackclub.com/',
-        forUseBy: 'leaders'
-      },
-      {
         name: 'Branding & Logos',
         description: 'Make anything Hack Club branded',
         icon: 'like',
         external: true,
         url: 'https://hackclub.com/brand',
         forUseBy: 'everyone'
-      },
-      {
-        name: 'Stickers',
-        description: 'Get a box of stickers for your next meeting or event',
-        icon: 'sticker',
-        external: true,
-        url: 'http://forms.hackclub.com/club-stickers',
-        forUseBy: 'leaders'
       },
       {
         name: 'Nest Git',
@@ -355,14 +330,6 @@ export default [
         external: true,
         url: 'https://hackclub.com/slack',
         forUseBy: 'everyone'
-      },
-      {
-        name: 'Leadership Guide',
-        description: 'Advice on how to lead a club',
-        icon: 'docs-fill',
-        external: true,
-        url: 'https://guide.leaders.hackclub.com/#/',
-        forUseBy: 'leaders'
       },
       {
         name: 'DNS',
@@ -566,18 +533,6 @@ export default [
         forUseBy: 'clubbers'
       },
       {
-        name: 'Canva Pro',
-        description: 'Free Canva Pro for Hack Club Leaders',
-        img: '/cards/canva.png',
-        external: true,
-        url: 'https://hack.club/canva',
-        forUseBy: 'leaders',
-        fancy: true,
-        background: 'linear-gradient(rgba(0,0,0,0.35), rgba(0,0,0,0.35)), linear-gradient(135deg, #00C4D5 0%, #5A32FA 50%, #7D2AEB 100%)',
-        titleColor: '#ffffff',
-        descriptionColor: '#ffffff'
-      },
-      {
         name: 'CodeDay',
         description: 'Discount for in-person CodeDay events',
         icon: 'event-code',
@@ -630,6 +585,58 @@ export default [
         descriptionColor: "#c4b5fd",
         slack: { name: 'hackclub-ai', id: 'C099S1LLFFU' }
       },
+    ]
+  },
+  {
+    category: 'Club Leaders',
+    color: 'blue',
+    icon: 'clubs',
+    items: [
+      {
+        name: 'Posters',
+        description: 'Get large Hack Club posters to promote your Hack Club (US)',
+        icon: 'docs-fill',
+        external: true,
+        url: 'https://forms.hackclub.com/club-stickers',
+        forUseBy: 'leaders'
+      },
+      {
+        name: 'International Posters',
+        description:
+          "If you're outside of the US, get large Hack Club posters to promote your Hack Club",
+        icon: 'docs-fill',
+        external: true,
+        url: 'https://are-we-there-yet.hackclub.com/',
+        forUseBy: 'leaders'
+      },
+      {
+        name: 'Leadership Guide',
+        description: 'Advice on how to lead a club',
+        icon: 'docs-fill',
+        external: true,
+        url: 'https://guide.leaders.hackclub.com/#/',
+        forUseBy: 'leaders'
+      },
+      {
+        name: 'Canva Pro',
+        description: 'Free Canva Pro for Hack Club Leaders',
+        img: '/cards/canva.png',
+        external: true,
+        url: 'https://hack.club/canva',
+        forUseBy: 'leaders',
+        fancy: true,
+        background: 'linear-gradient(rgba(0,0,0,0.35), rgba(0,0,0,0.35)), linear-gradient(135deg, #00C4D5 0%, #5A32FA 50%, #7D2AEB 100%)',
+        titleColor: '#ffffff',
+        descriptionColor: '#ffffff'
+      },
+      {
+        name: 'Stickers',
+        description: 'Get a box of stickers for your next meeting or event',
+        icon: 'sticker',
+        external: true,
+        url: 'http://forms.hackclub.com/club-stickers',
+        forUseBy: 'leaders'
+      }
     ]
   }
 ]

--- a/manifest.js
+++ b/manifest.js
@@ -328,6 +328,18 @@ xexport default [
         forUseBy: 'leaders'
       },
       {
+        name: 'Nest Git',
+        description: 'A GitHub Alternative for Hack Clubbers; a painless, self-hosted Git service!',
+        icon: 'github',
+        external: true,
+        url: 'https://git.hackclub.app',
+        forUseBy: 'everyone',
+        fancy: true,
+        background: '#FFFFFF',
+        titleColor: '#D40000',
+        descriptionColor: '#18181C'
+      },
+      {
         name: 'School Toolbox',
         description: 'Resources to help with school admin or IT challenges',
         icon: 'briefcase',

--- a/manifest.js
+++ b/manifest.js
@@ -30,7 +30,7 @@ xexport default [
         name: 'CAD YSWSs',
         description:
           'Our 3D modeling You Ship, We Ships!',
-        img: '/cards/cad.png',
+        icon: '3d-rotate',
         external: true,
         url: 'https://cad.hackclub.com',
         forUseBy: 'everyone'

--- a/manifest.js
+++ b/manifest.js
@@ -1,4 +1,4 @@
-export default [
+xexport default [
   {
     category: 'YSWSs',
     color: 'green',
@@ -448,6 +448,7 @@ export default [
         descriptionColor: '#FFFFFF',
         slack: {name: 'nest', id: 'C056WDR3MQR' },
         forUseBy: 'everyone'
+      },
       {
         name: 'Scrapbook',
         description: 'Post devlogs about what you are building, for the world to see.',

--- a/manifest.js
+++ b/manifest.js
@@ -440,15 +440,14 @@ export default [
       {
         name: 'Nest',
         description: 'Nest is a free Linux server from Hack Club to host Discord bots, apps, website, try out basic computer networking, chat with others and much more!',
-        img: '',
+        icon: 'hdd-stack',
         external: true,
         url: 'https://hackclub.app/',
         background: '#06001C',
         titleColor: 'A633D6',
         descriptionColor: '#FFFFFF',
         slack: {name: 'nest', id: 'C056WDR3MQR' },
-        forUseBy: 'everyone',
-        fancy: true
+        forUseBy: 'everyone'
       {
         name: 'Scrapbook',
         description: 'Post devlogs about what you are building, for the world to see.',

--- a/manifest.js
+++ b/manifest.js
@@ -438,6 +438,18 @@ export default [
         fancy: true
       },
       {
+        name: 'Nest',
+        description: 'Nest is a free Linux server from Hack Club to host Discord bots, apps, website, try out basic computer networking, chat with others and much more!',
+        img: '',
+        external: true,
+        url: 'https://hackclub.app/',
+        background: '#06001C',
+        titleColor: 'A633D6',
+        descriptionColor: '#FFFFFF',
+        slack: {name: 'nest', id: 'C056WDR3MQR' },
+        forUseBy: 'everyone',
+        fancy: true
+      {
         name: 'Scrapbook',
         description: 'Post devlogs about what you are building, for the world to see.',
         icon: 'photo-fill',

--- a/manifest.js
+++ b/manifest.js
@@ -1,4 +1,4 @@
-xexport default [
+export default [
   {
     category: 'YSWSs',
     color: 'green',

--- a/manifest.js
+++ b/manifest.js
@@ -485,6 +485,7 @@ export default [
         external: true,
         url: 'https://printlegion.hackclub.com/',
         fancy: true
+      },
       {
         name: 'Hack Club Auth',
         description: 'View and manage your personal information shared with Hack Club applications and programs',

--- a/manifest.js
+++ b/manifest.js
@@ -509,6 +509,16 @@ xexport default [
         fancy: true,
       },
       {
+        name: 'Print Legion',
+        description: 'An International Network of 3D Printers from Hack Club - available for Hack Club YSWS programs!',
+        icon: '3d-rotate',
+        background: '#F2F0E5',
+        titleColor: '#CE5D97',
+        descriptionColor: '#1C1C1A',
+        external: true,
+        url: 'https://printlegion.hackclub.com/',
+        fancy: true
+      {
         name: 'Hack Club Auth',
         description: 'View and manage your personal information shared with Hack Club applications and programs',
         icon: 'private-outline',


### PR DESCRIPTION
## Summary of Changes!

This PR slightly reorganises the Toolbox manifest.js to make resources for leaders easier to discover while adding missing 'cards' to the toolbox.

### List of changes

- Add a new Club Leaders category
- Move leader-only resources out of Resources and into Club Leaders 
  - Posters
  - International Posters
  - Leadership Guide
  - Canva Pro
  - Stickers
 - Add the following new resources:
   - Nest
   - Nest Git 
   - Print Legion
 - Modified the CAD YSWSs card to use the '3d-rotate' icon - as the current icon appears broken 

## Screenshots of Update 

![image](https://github.com/user-attachments/assets/d2c7f52e-4165-4fe9-ac9a-8d802c3ce982)

![image](https://github.com/user-attachments/assets/9be44449-e13b-44a5-9b67-e58738d6ca01)

![image](https://github.com/user-attachments/assets/70891332-36eb-4b27-99d8-f26a045f93c5)

![image](https://github.com/user-attachments/assets/4e017b8a-403a-4a88-bf43-0ea4ac9f6d24)

![image](https://github.com/user-attachments/assets/dc5d5a03-5ef4-4db3-986b-0985c90afdc9)